### PR TITLE
Reverting to coap-tcp-tls-08

### DIFF
--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -1153,10 +1153,7 @@ using CoAP over WebSockets secured by TLS.
 The port subcomponent is OPTIONAL. The default is port 443.
 
 The WebSocket endpoint is identified by a "wss" URI that is composed of the authority
-part of the "coaps+ws" URI and the well-known path "/.well-known/coap" {{RFC5785}}.
-The present specification formally updates {{RFC6455}}, extending the
-well-known URI mechanism defined in {{RFC5785}} to also cover the "wss"
-URI scheme defined in that document.
+part of the "coaps+ws" URI and the well-known path "/.well-known/coap" {{RFC5785}} {{-ws-wk}}.
 The path and query parts of a "coaps+ws" URI identify a resource within the specified
 endpoint which can be operated on by the methods defined by CoAP.
 

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -165,7 +165,11 @@ Currently, there are also fewer HTTP/2 implementations available for constrained
 comparison to CoAP.
 
 To address these requirements, this document defines how to transport CoAP over TCP,
-CoAP over TLS, and CoAP over WebSockets. {{layering}} illustrates the layering:
+CoAP over TLS, and CoAP over WebSockets. For these cases, the reliability offered by the
+transport protocol subsumes the reliability functions of the message layer used for CoAP
+over UDP. (Note that both for a reliable transport and the CoAP over UDP message layer, the reliability offered is per transport hop: where proxies --- see Sections 5.7 and 10 of
+{{-coap}} --- are involved, that layer's reliability function does not extend end-to-end.)
+{{fig-layering}} illustrates the layering:
 
 ~~~~
         +--------------------------------+
@@ -179,7 +183,7 @@ CoAP over TLS, and CoAP over WebSockets. {{layering}} illustrates the layering:
         |      Reliable Transport        |
         +--------------------------------+
 ~~~~
-{: #layering title='Layering of CoAP over Reliable Transports' artwork-align="center"}
+{: #fig-layering title='Layering of CoAP over Reliable Transports' artwork-align="center"}
 
 Where NATs are present, CoAP over TCP can help with their traversal.
 NATs often calculate expiration timers based on the transport layer protocol

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -173,16 +173,16 @@ over UDP. (Note that both for a reliable transport and the CoAP over UDP message
 {{fig-layering}} illustrates the layering:
 
 ~~~~
-        +--------------------------------+
-        |          Application           |
-        +--------------------------------+
-        +--------------------------------+
-        |  Requests/Responses/Signaling  |  CoAP (RFC 7252) / This Document
-        |--------------------------------|
-        |        Message Framing         |  This Document
-        +--------------------------------+
-        |      Reliable Transport        |
-        +--------------------------------+
+  +--------------------------------+
+  |          Application           |
+  +--------------------------------+
+  +--------------------------------+
+  |  Requests/Responses/Signaling  |  CoAP (RFC 7252) / This Document
+  |--------------------------------|
+  |        Message Framing         |  This Document
+  +--------------------------------+
+  |      Reliable Transport        |
+  +--------------------------------+
 ~~~~
 {: #fig-layering title='Layering of CoAP over Reliable Transports' artwork-align="center"}
 
@@ -1416,11 +1416,11 @@ Initial entries in this sub-registry are as follows:
 
 | Code | Name    | Reference |
 |------|---------|-----------|
-| 7.01 | CSM     | [RFCthis] |
-| 7.02 | Ping    | [RFCthis] |
-| 7.03 | Pong    | [RFCthis] |
-| 7.04 | Release | [RFCthis] |
-| 7.05 | Abort   | [RFCthis] |
+| 7.01 | CSM     | \[RFCthis] |
+| 7.02 | Ping    | \[RFCthis] |
+| 7.03 | Pong    | \[RFCthis] |
+| 7.04 | Release | \[RFCthis] |
+| 7.05 | Abort   | \[RFCthis] |
 {: #signal-codes title="CoAP Signal Codes" }
 
 All other Signaling Codes are Unassigned.
@@ -1443,12 +1443,12 @@ Initial entries in this sub-registry are as follows:
 
 | Applies to | Number | Name                | Reference |
 |------------|--------|---------------------|-----------|
-| 7.01       |      2 | Max-Message-Size    | [RFCthis] |
-| 7.01       |      4 | Block-wise-Transfer | [RFCthis] |
-| 7.02, 7.03 |      2 | Custody             | [RFCthis] |
-| 7.04       |      2 | Alternative-Address | [RFCthis] |
-| 7.04       |      4 | Hold-Off            | [RFCthis] |
-| 7.05       |      2 | Bad-CSM-Option      | [RFCthis] |
+| 7.01       |      2 | Max-Message-Size    | \[RFCthis] |
+| 7.01       |      4 | Block-wise-Transfer | \[RFCthis] |
+| 7.02, 7.03 |      2 | Custody             | \[RFCthis] |
+| 7.04       |      2 | Alternative-Address | \[RFCthis] |
+| 7.04       |      4 | Hold-Off            | \[RFCthis] |
+| 7.05       |      2 | Bad-CSM-Option      | \[RFCthis] |
 {: #signal-option-codes title="CoAP Signal Option Codes" cols="l r l c"}
 
 The IANA policy for future additions to this sub-registry is based on
@@ -1487,7 +1487,7 @@ Description.
 :   Constrained Application Protocol (CoAP)
 
 Reference.
-:   [RFCthis]
+:   \[RFCthis]
 
 Port Number.
 :   5683
@@ -1516,7 +1516,7 @@ Description.
 :   Constrained Application Protocol (CoAP)
 
 Reference.
-:  {{-alpn}}, [RFCthis]
+:  {{-alpn}}, \[RFCthis]
 
 Port Number.
 :   5684
@@ -1547,7 +1547,7 @@ Change controller:
 :   IESG \<iesg@ietf.org>
 
 Reference:
-:   {{coap-tcp-scheme}} in [RFCthis]
+:   {{coap-tcp-scheme}} in \[RFCthis]
 {: vspace='0'}
 
 ###coaps+tcp
@@ -1570,7 +1570,7 @@ Change controller:
 :   IESG \<iesg@ietf.org>
 
 Reference:
-:   {{coaps-tcp-scheme}} in [RFCthis]
+:   {{coaps-tcp-scheme}} in \[RFCthis]
 {: vspace='0'}
 
 ### coap+ws
@@ -1594,7 +1594,7 @@ Change controller:
 :   IESG \<iesg@ietf.org>
 
 Reference:
-:   {{coap-ws-scheme}} in [RFCthis]
+:   {{coap-ws-scheme}} in \[RFCthis]
 {: vspace='0'}
 
 ### coaps+ws
@@ -1618,7 +1618,7 @@ Change controller:
 :   IESG \<iesg@ietf.org>
 
 References:
-:   {{coaps-ws-scheme}} in [RFCthis]
+:   {{coaps-ws-scheme}} in \[RFCthis]
 {: vspace='0'}
 
 ## Well-Known URI Suffix Registration
@@ -1633,7 +1633,7 @@ Change controller.
 :   IETF
 
 Specification document(s).
-:   [RFCthis]
+:   \[RFCthis]
 
 Related information.
 :   None.
@@ -1652,7 +1652,7 @@ Identification Sequence.
 :   0x63 0x6f 0x61 0x70 ("coap")
 
 Reference.
-:   [RFCthis]
+:   \[RFCthis]
 {: vspace='0'}
 
 ## WebSocket Subprotocol Registration
@@ -1666,18 +1666,18 @@ Subprotocol Common Name.
 :   Constrained Application Protocol (CoAP)
 
 Subprotocol Definition.
-:   [RFCthis]
+:   \[RFCthis]
 {: vspace='0'}
 
 ## CoAP Option Numbers Registry
 
-IANA is requested to add [RFCthis] to the references for the following entries registered
+IANA is requested to add \[RFCthis] to the references for the following entries registered
 by {{RFC7959}} in the "CoAP Option Numbers" sub-registry defined by {{RFC7252}}:
 
 | Number | Name   | Reference           |
 |--------|--------|---------------------|
-| 23     | Block2 | RFC 7959, [RFCthis] |
-| 27     | Block1 | RFC 7959, [RFCthis] |
+| 23     | Block2 | RFC 7959, \[RFCthis] |
+| 27     | Block1 | RFC 7959, \[RFCthis] |
 {: #option-numbers title="CoAP Option Numbers" }
 --- back
 
@@ -1814,7 +1814,7 @@ CoAP messages exchanged in detail.
 
 {{example-2}} shows how a CoAP client uses a CoAP
 forward proxy with a WebSocket endpoint to retrieve the representation
-of the resource "coap://[2001:db8::1]/". The use of the forward
+of the resource `coap://[2001:db8::1]/`. The use of the forward
 proxy and the address of the WebSocket endpoint are determined by the
 client from local configuration rules. The request URI is specified
 in the Proxy-Uri Option. Since the request URI uses the "coap" URI

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -368,7 +368,7 @@ specified for CoAP over UDP. The differences are as follows:
 {: #fig-frame title='CoAP frame for reliable transports'}
 
 Length (Len):
-: 4-bit unsigned integer. A value between 0 and 12 directly indicates the
+: 4-bit unsigned integer. A value between 0 and 12 inclusive indicates the
   length of the message in bytes starting with the first bit of the Options
   field. Three values are reserved for special constructs:
 
@@ -712,8 +712,8 @@ capability and setting before any Capabilities and Settings messages send a
 modified value.
 
 These are not default values for the option, as defined in Section 5.4.4 in {{RFC7252}}.
-A default value would mean that an empty Capabilities and Settings message would result in
-the option being set to its default value.
+Default values apply on a per-message basis and thus reset when the value is not present in 
+a given Capabilities and Settings message.
 
 Capabilities and Settings messages are indicated by the 7.01 code (CSM).
 

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -1042,7 +1042,7 @@ using CoAP over TCP.
 
 The syntax defined in Section 6.1 of {{RFC7252}} applies to this URI scheme with the following changes:
 
-* The port subcomponent indicates the TCP port at which the CoAP server is located.
+* The port subcomponent indicates the TCP port at which the CoAP Connection Acceptor is located.
 (If it is empty or not given, then the default port 5683 is assumed, as with UDP.)
 
 Encoding considerations:
@@ -1068,7 +1068,7 @@ using CoAP over TCP secured with TLS.
 The syntax defined in Section 6.2 of {{RFC7252}} applies to this URI scheme, with the following changes:
 
 * The port subcomponent indicates the TCP port at which the TLS server
-  for the CoAP server is located. If it is empty or not given, then
+  for the CoAP Connection Acceptor is located. If it is empty or not given, then
   the default port 5684 is assumed.
 
 * If a TLS server does not support the Application-Layer Protocol Negotiation Extension (ALPN)

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -78,7 +78,6 @@ normative:
   RFC0793: tcp
   RFC2119: bcp14
   RFC3986: RFC3986
-  RFC5226: RFC5226
   RFC5246: tls12
   RFC5785: RFC5785
   RFC6066: RFC6066
@@ -90,6 +89,7 @@ normative:
   RFC7641: RFC7641
   RFC7925: RFC7925
   RFC7959: block
+  RFC8126: RFC8126
   I-D.bormann-hybi-ws-wk: ws-wk 
 informative:
   I-D.ietf-core-cocoa: cocoa
@@ -1373,7 +1373,7 @@ Initial entries in this sub-registry are as follows:
 All other Signaling Codes are Unassigned.
 
 The IANA policy for future additions to this sub-registry is "IETF
-Review or IESG Approval" as described in {{RFC5226}}.
+Review or IESG Approval" as described in {{RFC8126}}.
 
 ## CoAP Signaling Option Numbers Registry {#option-codes}
 

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -263,18 +263,6 @@ Connection Acceptor:
     the other peer, i.e., the TCP passive opener, TLS server, or
     WebSocket server.
 
-For simplicity, a Payload Marker (0xFF) is shown in all examples for message formats:
-
-~~~~
-    ...
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    |1 1 1 1 1 1 1 1|    Payload (if any) ...
-    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~~
-
-The Payload Marker indicates the start of the optional payload and is absent for zero-length
-payloads (see Section 3 of {{RFC7252}}).
-
 # CoAP over TCP
 
 The request/response interaction model of CoAP over TCP is the same as CoAP over UDP.
@@ -362,21 +350,22 @@ specified for CoAP over UDP. The differences are as follows:
   length field with variable size. {{fig-frame}} shows the adjusted CoAP 
   message format with a modified structure for the fixed header (first 4
   bytes of the CoAP over UDP header), which includes the length information of
-  variable size, shown here as an 8-bit length.
+  variable size.
 
 ~~~~
-
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|Len=13 |  TKL  |Extended Length|      Code     | TKL bytes ...
+|  Len  |  TKL  | Extended Length (if any, as chosen by Len) ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|      Code     | Token (if any, TKL bytes) ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |  Options (if any) ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |1 1 1 1 1 1 1 1|    Payload (if any) ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ~~~~
-{: #fig-frame title='CoAP frame with 8-bit Extended Length field'}
+{: #fig-frame title='CoAP frame for reliable transports'}
 
 Length (Len):
 : 4-bit unsigned integer. A value between 0 and 12 directly indicates the
@@ -399,24 +388,15 @@ Length (Len):
 
 The encoding of the Length field is modeled after the Option Length field of the CoAP Options (see Section 3.1 of {{RFC7252}}).
 
-The following figures show the message format for the 0-bit, 16-bit, and
-the 32-bit variable length cases.
-
-~~~~
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|  Len  |  TKL  |      Code     | Token (if any, TKL bytes) ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|  Options (if any) ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|1 1 1 1 1 1 1 1|    Payload (if any) ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~~
-{: #fig-frame1 title='CoAP message format without an Extended Length field'}
+For simplicity, a Payload Marker (0xFF) is shown in {{fig-frame}}; the
+Payload Marker indicates the start of the optional payload and is
+absent for zero-length payloads (see Section 3 of {{RFC7252}}).
+(If present, the Payload Marker is included in the message length,
+which counts from the start of the Options field to the end of the
+Payload field.)
 
 For example: A CoAP message just containing a 2.03 code with the
-token 7f and no options or payload would be encoded as shown in {{fig-frame2}}.
+token 7f and no options or payload is encoded as shown in {{fig-frame2}}.
 
 ~~~~
  0                   1                   2
@@ -431,36 +411,6 @@ token 7f and no options or payload would be encoded as shown in {{fig-frame2}}.
  Token =               0x7f
 ~~~~
 {: #fig-frame2 title='CoAP message with no options or payload'}
-
-~~~~
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|Len=14 |  TKL  | Extended Length (16 bits)     |   Code        |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|   Token (if any, TKL bytes) ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|   Options (if any) ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|1 1 1 1 1 1 1 1|    Payload (if any) ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~~
-{: #fig-frame3 title='CoAP message format with 16-bit Extended Length field'}
-
-~~~~
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|Len=15 |  TKL  | Extended Length (32 bits)
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-                |    Code       |  Token (if any, TKL bytes) ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|   Options (if any) ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|1 1 1 1 1 1 1 1|    Payload (if any) ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~~
-{: #fig-frame4 title='CoAP message format with 32-bit Extended Length field'}
 
 The semantics of the other CoAP header fields are left unchanged.
 

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -1161,10 +1161,7 @@ using CoAP over WebSockets.
 The port subcomponent is OPTIONAL. The default is port 80.
 
 The WebSocket endpoint is identified by a "ws" URI that is composed of the authority
-part of the "coap+ws" URI and the well-known path "/.well-known/coap" {{RFC5785}}.
-The present specification formally updates {{RFC6455}}, extending the
-well-known URI mechanism defined in {{RFC5785}} to also cover the "ws"
-URI scheme defined in that document.
+part of the "coap+ws" URI and the well-known path "/.well-known/coap" {{RFC5785}} {{-ws-wk}}.
 The path and query parts of a "coap+ws" URI identify a resource within the specified
 endpoint which can be operated on by the methods defined by CoAP:
 

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -608,9 +608,7 @@ connection is established as defined in Section 4 of {{RFC6455}}.
 
 The WebSocket client MUST include the subprotocol name "coap" in
 the list of protocols, which indicates support for the protocol
-defined in this document. Any later, incompatible versions of
-CoAP or CoAP over WebSockets will use a different subprotocol
-name.
+defined in this document.
 
 The WebSocket client includes the hostname of the WebSocket server
 in the Host header field of its handshake as per {{RFC6455}}. The Host

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -1926,6 +1926,11 @@ Michael Koster, Matthias Kovatsch, Achim Kraus, David Navarro,
 Szymon Sasin, Goran Selander, Zach Shelby, Andrew Summers, Julien Vermillard,
 and Gengyu Wei for their feedback.
 
+Last-call reviews from Mark Nottingham and Yoshifumi Nishida as well
+as several IESG reviewers provided extensive comments; from the IESG, 
+we would like to specifically call out Adam Roach, Ben Campbell, Eric 
+Rescorla, Mirja Kühlewind, and the responsible AD Alexey Melnikov. 
+
 # Contributors {#contributors}
 {: numbered="no"}
 

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -843,8 +843,10 @@ maintaining the connection and opts for an orderly shutdown. The details
 are in the options. A diagnostic payload (see Section
 5.5.2 of {{-coap}}) MAY be included.  A peer will normally
 respond to a Release message by closing the TCP/TLS connection.
-Messages may be in flight when the sender decides to send a Release message.
-The general expectation is that these will still be processed.
+Messages may be in flight or responses outstanding when the sender decides to
+send a Release message. The peer responding to the Release message SHOULD delay
+the closing of the connection until it has responded to all requests received by it
+before the Release message. It also MAY wait for the responses to its own requests.
 
 Release messages are indicated by the 7.04 code (Release).
 
@@ -880,7 +882,7 @@ release. The sender shuts down the connection immediately after
 the abort (and may or may not wait for a Release or Abort message or
 connection shutdown in the inverse direction). A diagnostic payload
 (see Section 5.5.2 of {{-coap}}) SHOULD be included in the Abort message.
-Messages may be in flight when the sender decides to send an Abort message.
+Messages may be in flight or responses outstanding when the sender decides to send an Abort message.
 The general expectation is that these will NOT be processed.
 
 Abort messages are indicated by the 7.05 code (Abort).

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -976,8 +976,9 @@ block instead.
 
 In descriptive usage, a BERT Option is interpreted in the same way as
 the equivalent Option with SZX == 6, except that the payload is also
-allowed to contain a multiple of 1024 bytes (non-final BERT block) or
-more than 1024 bytes (final BERT block).
+allowed to contain multiple blocks. For non-final BERT blocks, the payload
+is always a multiple of 1024 bytes. For final BERT blocks, the payload is
+a multiple (possibly 0) of 1024 bytes plus a partial block of less than 1024 bytes.
 
 The recipient of a non-final BERT block (M=1) conceptually partitions
 the payload into a sequence of 1024-byte blocks and acts exactly as

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -1940,10 +1940,10 @@ Michael Koster, Matthias Kovatsch, Achim Kraus, David Navarro,
 Szymon Sasin, Goran Selander, Zach Shelby, Andrew Summers, Julien Vermillard,
 and Gengyu Wei for their feedback.
 
-Last-call reviews from Mark Nottingham and Yoshifumi Nishida as well
-as several IESG reviewers provided extensive comments; from the IESG, 
-we would like to specifically call out Adam Roach, Ben Campbell, Eric 
-Rescorla, Mirja Kühlewind, and the responsible AD Alexey Melnikov. 
+Last-call reviews from Yoshifumi Nishida, Mark Nottingham, and
+Meral Shirazipour as well as several IESG reviewers provided extensive
+comments; from the IESG, we would like to specifically call out Ben Campbell,
+Mirja Kühlewind, Eric Rescorla, Adam Roach, and the responsible AD Alexey Melnikov. 
 
 # Contributors {#contributors}
 {: numbered="no"}

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -3,7 +3,7 @@ stand_alone: true
 ipr: trust200902
 docname: draft-ietf-core-coap-tcp-tls-latest
 cat: std
-updates: 6455, 7641, 7959
+updates: 7641, 7959
 coding: utf-8
 pi:
   strict: 'yes'
@@ -139,9 +139,8 @@ reliable delivery, simple congestion control, and flow control.
 Some environments benefit from the availability of CoAP carried over reliable
 transports such as TCP or TLS. This document outlines the changes required to use
 CoAP over TCP, TLS, and WebSockets transports. It also formally updates RFC 7641
-for use with these transports, RFC 7959 to enable the use of larger messages over
-a reliable transport, and RFC 6455 to extend the well-known URI mechanism (RFC 5785)
-to the ws and wss URI schemes.
+for use with these transports and RFC 7959 to enable the use of larger messages over
+a reliable transport.
 
 --- middle
 

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -79,12 +79,13 @@ normative:
   RFC2119: bcp14
   RFC3986: RFC3986
   RFC5226: RFC5226
-  RFC5246: tls
+  RFC5246: tls12
   RFC5785: RFC5785
   RFC6066: RFC6066
   RFC6455: RFC6455
   RFC7252: coap
   RFC7301: alpn
+  RFC7525: tlsbcp
   RFC7595: urireg
   RFC7641: RFC7641
   RFC7925: RFC7925
@@ -1334,7 +1335,11 @@ data object-based security model for CoAP that is independent of transport
 
 ## TLS binding for CoAP over TCP
 
-The TLS usage guidance in {{RFC7925}} applies.
+The TLS usage guidance in {{RFC7925}} applies, including the guidance about cipher suites
+in that document that are derived from the mandatory-to-implement (MTI) cipher suites defined
+in {{-coap}}. (Note that this selection caters for the device-to-cloud use case of CoAP over TLS
+more than for any use within a back-end environment, where the standard TLS 1.2 cipher suites or
+the more recent ones defined in {{-tlsbcp}} are more appropriate.)
 
 During the provisioning phase, a CoAP device is provided with the security information
 that it needs, including keying materials, access control lists, and authorization servers.
@@ -1375,6 +1380,12 @@ Section 4.1 of {{RFC6455}} applies. When a CoAP server exposes resources identif
 the guidance in Section 4.4 of {{RFC7925}} applies towards mandatory-to-implement TLS functionality
 for certificates. For the server-side requirements in accepting incoming connections over a HTTPS
 (HTTP-over-TLS) port, the guidance in Section 4.2 of {{RFC6455}} applies.
+
+Note that this formally inherits the mandatory-to-implement cipher suites defined in {{-tls12}}. 
+However, usually modern browsers implement more recent cipher suites that then are automatically
+picked up via the JavaScript WebSocket API. WebSocket Servers that provide Secure CoAP over 
+WebSockets for the browser use case will need to follow the browser preferences and MUST follow
+{{-tlsbcp}}. 
 
 # Security Considerations {#security}
 
@@ -1846,7 +1857,7 @@ the WebSocket connection to the client.
      |          |          |    +------------------------------------+
      |          |          |
 ~~~~
-{: #example-2 title='A CoAP client retrieves the representation of a resource identified by a "coap" URI via a WebSockets-enabled CoAP proxy'}
+{: #example-2 title='A CoAP client retrieves the representation of a resource identified by a "coap" URI via a WebSocket-enabled CoAP proxy'}
 
 # Change Log
 

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -759,8 +759,8 @@ by the recipient. This provides a basic keep-alive function. In contrast, Ping a
 a bidirectional exchange.
 
 Upon receipt of a Ping message, the receiver MUST return a Pong message with an identical token
-in response. Unless there is an option with delaying semantics such as the Custody Option, it
-SHOULD respond as soon as practical. As with all Signaling messages, the recipient of a Ping or
+in response. Unless the Ping carries an option with delaying semantics such as the Custody Option,
+it SHOULD respond as soon as practical. As with all Signaling messages, the recipient of a Ping or
 Pong message MUST ignore elective options it does not understand.
 
 Ping and Pong messages are indicated by the 7.02 code (Ping) and the 7.03 code (Pong).

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -1113,8 +1113,7 @@ The syntax defined in Section 6.2 of {{RFC7252}} applies to this URI scheme, wit
 
 * The port subcomponent indicates the TCP port at which the TLS server
   for the CoAP server is located. If it is empty or not given, then
-  the default port 443 is assumed (this is different from the default
-  port for "coaps", i.e., CoAP over DTLS over UDP).
+  the default port 5684 is assumed.
 
 * If a TLS server does not support the Application-Layer Protocol Negotiation Extension (ALPN)
   {{-alpn}} or wishes to accommodate TLS clients that do not support ALPN, it MAY offer a

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -89,6 +89,7 @@ normative:
   RFC7641: RFC7641
   RFC7925: RFC7925
   RFC7959: block
+  I-D.bormann-hybi-ws-wk: ws-wk 
 informative:
   I-D.ietf-core-cocoa: cocoa
   I-D.ietf-core-object-security: oscoap

--- a/draft-ietf-core-coap-tcp-tls.md
+++ b/draft-ietf-core-coap-tcp-tls.md
@@ -905,8 +905,8 @@ of {{RFC7252}}, such messages are rejected by sending a matching Reset
 message and otherwise ignoring the message. 
 
 For CoAP over reliable transports, the recipient rejects such messages by
-sending an Abort message and otherwise ignoring the message. No specific option
-has been defined for the Abort message in this case, as the details are
+sending an Abort message and otherwise ignoring (not processing) the message.
+No specific option has been defined for the Abort message in this case, as the details are
 best left to a diagnostic payload.
 
 ## Signaling examples


### PR DESCRIPTION
I've reverted to the -08 tag in the initial commit and am gradually (and manually) layering in -09 commits that remain applicable. 

I've skipped the commits below - please review for a second opinion - 

https://github.com/core-wg/coap-tcp-tls/pull/166/commits/6b3085f5dfc6f7cb2b69b934755b06b17b582699

https://github.com/core-wg/coap-tcp-tls/pull/168/commits/079f1f2d5d3de929232db60a50dcc3efb3294c64

Closes #178 